### PR TITLE
Qolsvc 1099 ptss styling

### DIFF
--- a/css/qg-ptss.css
+++ b/css/qg-ptss.css
@@ -2,7 +2,7 @@
 
 .qg-preamble {
     height: 215px;
-    margin: -50px -50px 1em -50px;
+    margin: 0;
     position: relative;
     box-sizing: border-box;
     padding: 1px;


### PR DESCRIPTION
https://ssq-qol.atlassian.net/browse/QOLSVC-1099

The image in the middle column does not sit well in production specially in 992-1199px.

Before:
https://www.qld.gov.au/health/services/travel/subsidies/ptss-forms

After:
https://oss-uat.clients.squiz.net/health/services/travel/subsidies/ptss-forms

![image](https://user-images.githubusercontent.com/126438691/225780579-dc43e6d3-a84c-4f4c-b407-3744d27628c7.png)
